### PR TITLE
feat: adiciona docker-compose, script e atualiza README

### DIFF
--- a/FCG.sln
+++ b/FCG.sln
@@ -29,7 +29,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		.dockerignore = .dockerignore
-		docker-composemynl.txt = docker-composemynl.txt
+		docker-compose.yml = docker-compose.yml
 		dockerfile = dockerfile
 		README.md = README.md
 		traffic-generator.sh = traffic-generator.sh

--- a/FCG.sln
+++ b/FCG.sln
@@ -29,8 +29,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		.dockerignore = .dockerignore
+		docker-composemynl.txt = docker-composemynl.txt
 		dockerfile = dockerfile
 		README.md = README.md
+		traffic-generator.sh = traffic-generator.sh
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -134,18 +134,18 @@ Você pode executar a aplicação facilmente usando Docker.
 ### Build da imagem
 
 ```bash 
-docker build -t fcg-api .
+docker-compose up --build -d
 ```
 
-### Executando o container
+### Verificando se os containers estão rodando
 
 ```bash 
-docker run -d -p 8080:80 --name fcg-api-container fcg-api
+docker ps
 ```
 
 - A API estará disponível em [http://localhost:8080](http://localhost:8080)
-- O parâmetro `-p 8080:80` mapeia a porta 80 do container para a porta 8080 do host.
-- O nome do container será `fcg-api-container`.
+- O docker-compose.yml mapeia a porta 80 do container para a porta 8080 do host
+- O serviço principal está definido com o nome fcg-api (ou conforme configurado no compose)
 
 > Certifique-se de configurar corretamente a string de conexão com o banco de dados PostgreSQL no arquivo `appsettings.json` ou via variáveis de ambiente.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ O sistema já vem com dados iniciais configurados:
 - **Admin**: `admin@fcg.com` / `Admin@123` > Pendente criar
 - **Usuário**: `user@fcg.com` / `User123!` -> Pendente criar
 
+## 🚦 Geração de Tráfego para Monitoramento
+
+Para facilitar o monitoramento e teste da aplicação, incluímos um script que gera requisições contínuas simulando o uso real da API, ajudando a alimentar métricas e traces no Datadog.
+
+### Executando o script de geração de tráfego
+
+1. Certifique-se que a aplicação e o Datadog Agent estejam rodando via Docker Compose.
+
+2. O script `traffic-generator.sh` realiza:
+
+- Autenticação uma única vez para obter o token JWT.
+- Várias chamadas para endpoints principais, utilizando o token obtido.
+- Requisições adicionais para endpoints de teste e health check.
+
+3. Para rodar o script (em ambiente Linux/WSL):
+
+```bash
+chmod +x traffic-generator.sh
+
+./traffic-generator.sh
+```
+
 ## 📁 Estrutura do Projeto
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.8'
+
+services:
+  datadog-agent:
+    image: datadog/agent:latest
+    container_name: datadog-agent
+    network_mode: bridge
+    pid: host
+    ports:
+      - "127.0.0.1:8126:8126"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /opt/datadog-agent/run:/opt/datadog-agent/run:rwmake --version
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/datadog/:/var/run/datadog/
+      - /etc/passwd:/etc/passwd:ro
+    environment:
+      - DD_API_KEY=9d6cbc2d18c52c6b3c8bc0f0bfe216ca
+      - DD_SITE=datadoghq.com
+      - DD_HOSTNAME=fcg-api
+      - DD_APM_ENABLED=true
+      - DD_LOGS_ENABLED=true
+      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
+      - DD_CONTAINER_EXCLUDE_LOGS=name:datadog-agent
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+      - DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket
+      - DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED=true
+
+  fcg-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: fcg-api
+    container_name: fcg-api
+    depends_on:
+      - datadog-agent
+    network_mode: bridge
+    ports:
+      - "8080:80"
+    volumes:
+      - /var/run/datadog/:/var/run/datadog/
+    environment:
+      - DD_AGENT_HOST=host.docker.internal
+      - DD_ENV=dev
+      - DD_SERVICE=fcg-api
+      - DD_VERSION=1.0.0
+      - DD_LOGS_INJECTION=true
+      - DD_RUNTIME_METRICS_ENABLED=true
+      - DD_API_KEY=9d6cbc2d18c52c6b3c8bc0f0bfe216ca
+    labels:
+      com.datadoghq.tags.env: dev
+      com.datadoghq.tags.service: fcg-api
+      com.datadoghq.tags.version: 1.0.0
+      com.datadoghq.ad.logs: '[{"source":"csharp","service":"fcg-api"}]'

--- a/traffic-generator.sh
+++ b/traffic-generator.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Faz a autenticação uma vez e captura o token
+echo "Autenticando..."
+token=$(curl --silent --location 'http://localhost:8080/api/Auth/login' \
+  --header 'Content-Type: application/json' \
+  --header 'Accept: application/json' \
+  --data-raw '{
+    "email": "teste@teste.com",
+    "password": "teste@123"
+  }' | jq -r '.token')
+
+if [ -z "$token" ] || [ "$token" == "null" ]; then
+  echo "Erro ao obter token. Abortando."
+  exit 1
+fi
+
+echo "Token obtido: $token"
+
+for i in {1..10000}
+do
+  # Requests simples sem auth (health e fiap-dotnet)
+  curl -s -k -H 'header info' -b 'ff' "http://localhost:8080/health"
+  curl -s -k -H 'header info' -b 'ff' "http://localhost:8080/fiap-dotnet"
+
+  # Requests autenticados com o token obtido
+  curl --silent --location "http://localhost:8080/api/Games" \
+    --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $token" \
+    --data '{"categoryId":"016b7b0b-afee-4492-9b89-e26476ed1f31","name":"jogo teste","price":50,"description":"descrição teste","imageUrl":""}'
+
+  curl --silent --location "http://localhost:8080/api/games/simulate-db-error" \
+    --header "Authorization: Bearer $token"
+
+  curl --silent --location "http://localhost:8080/api/User" \
+    --header "Authorization: Bearer $token"
+
+  curl --silent --location "http://localhost:8080/api/Games" \
+    --header "Authorization: Bearer $token"
+
+done
+
+echo "Requisições finalizadas."


### PR DESCRIPTION
* Adiciona docker-compose para orquestrar fcg-api com Datadog Agent
* Adicionar script para geração de tráfego
* Atualiza README com instruções para build e execução local via docker-compose.
